### PR TITLE
Add branch-based container runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM php:7.3-fpm
+RUN apt-get update && apt-get install -y nginx \
+    && rm -rf /var/lib/apt/lists/*
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+WORKDIR /var/www/html
+COPY . .
+EXPOSE 80
+CMD service nginx start && php-fpm

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # runner
+
+This repository provides a small Flask application that lets users select a
+branch from a Gitea repository and run that branch in a Docker container.
+The container uses PHP 7.3 and nginx for running FrontAccounting or similar
+applications.
+
+## Requirements
+
+- Python 3
+- Flask (`pip install flask`)
+- Docker
+
+## Configuration
+
+Set the `GITEA_REPO_URL` environment variable to point to your Gitea
+repository. Optional environment variables:
+
+- `BASE_PORT` - starting port for launched containers (default `8000`).
+- `CLONE_ROOT` - directory for temporary clones (default `/tmp/branches`).
+- `HOST` - hostname used in links (default `localhost`).
+
+## Usage
+
+1. Install dependencies and start the Flask app:
+
+   ```bash
+   pip install flask
+   python app.py
+   ```
+
+2. Open `http://<server-ip>:5000` in a browser. Choose a branch to build and
+   run. The app clones the branch, builds a Docker image using the provided
+   `Dockerfile`, and runs the container on the next available port.
+
+3. The page shows the URL to access the running container.
+
+Cleanup old containers manually or extend the app to remove them when no longer
+needed.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,68 @@
+import os
+import subprocess
+import tempfile
+from flask import Flask, render_template_string, redirect, url_for
+
+GITEA_REPO_URL = os.environ.get('GITEA_REPO_URL', 'https://gitea.example.com/user/frontaccounting.git')
+BASE_PORT = int(os.environ.get('BASE_PORT', 8000))
+CLONE_ROOT = os.environ.get('CLONE_ROOT', '/tmp/branches')
+
+app = Flask(__name__)
+
+LIST_TEMPLATE = """
+<!doctype html>
+<title>Branch Runner</title>
+<h1>Select a Branch</h1>
+<ul>
+{% for branch in branches %}
+  <li><a href="{{ url_for('run_branch', branch=branch) }}">{{ branch }}</a></li>
+{% endfor %}
+</ul>
+"""
+
+RUN_TEMPLATE = """
+<!doctype html>
+<title>Running {{ branch }}</title>
+<p>Branch <b>{{ branch }}</b> launched on port {{ port }}.</p>
+<p>Access it via <a href="http://{{ host }}:{{ port }}/">http://{{ host }}:{{ port }}/</a></p>
+"""
+
+
+def list_branches():
+    result = subprocess.run([
+        'git', 'ls-remote', '--heads', GITEA_REPO_URL
+    ], check=True, capture_output=True, text=True)
+    branches = []
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and parts[1].startswith('refs/heads/'):
+            branches.append(parts[1].replace('refs/heads/', ''))
+    return branches
+
+
+def build_and_run(branch):
+    clone_dir = tempfile.mkdtemp(prefix=f'{branch}-', dir=CLONE_ROOT)
+    subprocess.run(['git', 'clone', '-b', branch, GITEA_REPO_URL, clone_dir], check=True)
+    tag = f'fa:{branch}'
+    subprocess.run(['docker', 'build', '-t', tag, clone_dir], check=True)
+    port = BASE_PORT + int(subprocess.check_output(['sh', '-c', 'ls -1q ' + CLONE_ROOT + ' | wc -l']).strip())
+    subprocess.run(['docker', 'run', '-d', '-p', f'{port}:80', tag], check=True)
+    return port
+
+
+@app.route('/')
+def index():
+    branches = list_branches()
+    return render_template_string(LIST_TEMPLATE, branches=branches)
+
+
+@app.route('/run/<branch>')
+def run_branch(branch):
+    port = build_and_run(branch)
+    host = os.environ.get('HOST', 'localhost')
+    return render_template_string(RUN_TEMPLATE, branch=branch, port=port, host=host)
+
+
+if __name__ == '__main__':
+    os.makedirs(CLONE_ROOT, exist_ok=True)
+    app.run(host='0.0.0.0', port=5000)

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,13 @@
+worker_processes auto;
+
+events { }
+
+http {
+    server {
+        listen 80;
+        root /var/www/html;
+        location / {
+            try_files $uri $uri/ =404;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- provide Dockerfile for PHP 7.3 & nginx
- add a lightweight Flask web UI to choose Gitea branches
- document setup and usage for running branches in containers

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684e5ce78e90832b9302c726fb13c841